### PR TITLE
Fix directional lighting placement

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -74,11 +74,13 @@ export class ViewerClient {
             this.controls.update(delta);
 
             requestAnimationFrame(animate);
+            const cameraPosition = this.camera.position;
+            const targetPosition = this.controls.getTarget(new THREE.Vector3())
 
             directionalLight.position.set(
-                this.camera.position.x * 1.1,
-                this.camera.position.y * 1.2,
-                this.camera.position.z * 3
+                cameraPosition.x + (cameraPosition.x - targetPosition.x) * 0.2,
+                cameraPosition.y + (cameraPosition.y - targetPosition.y) * 0.2,
+                cameraPosition.z + (cameraPosition.z - targetPosition.z) * 4.0
             );
 
             this.render();


### PR DESCRIPTION
Suggeted fix for the directional lighting misplacement. Addition based on camera position was simply replaced with multiplication. These values look good to me in the cross-species-mapper, but there's not much more thought behind them than 'looks good'. 

I've also removed some commented stuff to clean up the code a bit more. 