### PR TITLE
Add automated documentation with Typedoc

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,10 +22,8 @@ jobs:
       - run: |
           npm ci
           npx typedoc src/index.ts --out docs
-          tar -czf docs.tar.gz docs
         name: Create Docs
       - uses: actions/upload-pages-artifact@v2
         name: Upload Pages Artifact
         with:
-          name: docs
-          path: docs.tar.gz
+          path: ./docs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/docs
 
 jobs:
   build-docs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,30 @@
+name: npm run test
+
+on:
+  push:
+    branches:
+      - main
+      - feature/docs
+
+jobs:
+  create-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 19
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: |
+          npx typedoc src/index.ts --out docs
+          tar -czf docs.tar.gz docs
+        name: Create Docs
+      - uses: actions/upload-pages-artifact@v2
+        name: Upload Pages Artifact
+        with:
+          name: docs
+          path: docs.tar.gz

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,4 @@
-name: npm run test
+name: Generate Documentation
 
 on:
   push:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,6 +20,7 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: |
+          npm ci
           npx typedoc src/index.ts --out docs
           tar -czf docs.tar.gz docs
         name: Create Docs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,7 @@ on:
       - feature/docs
 
 jobs:
-  create-docs:
+  build-docs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,3 +27,20 @@ jobs:
         name: Upload Pages Artifact
         with:
           path: ./docs
+
+  deploy-docs:
+    needs: build-docs
+
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+docs
 .DS_Store
 playground
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # brainviewer
+
+BrainViewer is a tool for scientific visualization of 3D mesh data in
+Javascript/Typescript. It is built on top of the ThreeJS library. It provides a fast, responsive
+and easy to use interface for visualizing 3D meshes in the browser.
+
+## Installation
+
+BrainViewer can be installed with npm:
+
+```bash
+npm install @cmi-dair/brainviewer
+```
+
+## Usage
+
+The public API is still a WIP.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# brainviewer
+# BrainViewer
 
 BrainViewer is a tool for scientific visualization of 3D mesh data in
-Javascript/Typescript. It is built on top of the ThreeJS library. It provides a fast, responsive
-and easy to use interface for visualizing 3D meshes in the browser.
+Javascript/Typescript. It is built on top of the ThreeJS library. It provides a
+fast, responsive and easy to use interface for visualizing 3D meshes in the
+browser.
 
 ## Installation
 


### PR DESCRIPTION
This PR adds automated documentation with Typedoc. An example is available here https://cmi-dair.github.io/brainviewer/ (built from this branch on an old workflow that allowed builds from this branch). I've also added a very basic README, mostly to see how that interacts with Typedoc.

It seems to work very similarly to `pdoc`. 

@nx10 thoughts?